### PR TITLE
Tweak widths and opacity of highligher, paintbrush, calligraphy and ballpoint pen

### DIFF
--- a/src/rmc/exporters/writing_tools.py
+++ b/src/rmc/exporters/writing_tools.py
@@ -119,7 +119,7 @@ class Pen:
             return MechanicalPencil(width, color_id)
         # Highlighter
         elif pen_nr in (PenType.HIGHLIGHTER_1, PenType.HIGHLIGHTER_2):
-            width = 25
+            width = 30
             return Highlighter(width, color_id)
         elif pen_nr == PenType.SHADER:
             # TODO: check if this is correct
@@ -146,7 +146,7 @@ class Ballpoint(Pen):
         self.segment_length = 5
 
     def get_segment_width(self, speed, direction, width, pressure, last_width):
-        segment_width = (0.5 + pressure / 255) + (width / 4) - 0.5 * ((speed / 4) / 50)
+        segment_width = (0.5 + pressure / 255) + (width / 6.5) - 0.5 * ((speed / 4) / 50)
         return segment_width
 
 
@@ -199,7 +199,7 @@ class Brush(Pen):
 
     def get_segment_width(self, speed, direction, width, pressure, last_width):
         segment_width = 0.7 * (
-            ((1 + (1.4 * pressure / 255)) * (width / 4))
+            ((1 + (1.4 * pressure / 255)) * (width / 7))
             - (0.5 * self.direction_to_tilt(direction))
             - ((speed / 4) / 50)
         )  # + (0.2 * last_width)
@@ -210,8 +210,8 @@ class Highlighter(Pen):
     def __init__(self, base_width, base_color_id):
         super().__init__("Highlighter", base_width, base_color_id)
         self.stroke_linecap = "square"
-        self.base_opacity = 0.3
-        self.stroke_opacity = 0.3
+        self.base_opacity = 0.6
+        self.stroke_opacity = 0.6
 
 
 class Shader(Pen):
@@ -243,7 +243,7 @@ class Calligraphy(Pen):
 
     def get_segment_width(self, speed, direction, width, pressure, last_width):
         segment_width = 0.9 * (
-            ((1 + pressure / 255) * (width / 4))
-            - 0.3 * self.direction_to_tilt(direction)
+            ((1 + pressure / 255) * (width / 7))
+            - 0.1 * self.direction_to_tilt(direction)
         ) + (0.1 * last_width)
         return segment_width

--- a/src/rmc/exporters/writing_tools.py
+++ b/src/rmc/exporters/writing_tools.py
@@ -157,7 +157,7 @@ class Marker(Pen):
 
     def get_segment_width(self, speed, direction, width, pressure, last_width):
         segment_width = 0.9 * (
-            (width / 4) - 0.4 * self.direction_to_tilt(direction)
+            (width / 5) - 0.4 * self.direction_to_tilt(direction)
         ) + (0.1 * last_width)
         return segment_width
 


### PR DESCRIPTION
Adjusted the widths of the calligraphy and ballpoint pen, and the opacity of the highlighter.
This are two screenshots from the remarkable app of a notebook:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/3b151c72-2797-4114-82c2-d580a09a0979" />
<img width="430" alt="image" src="https://github.com/user-attachments/assets/0745fcc0-768f-476f-8a2b-3c74b856bbcb" />

These are the same screenshots with current remarks:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/4d10d560-e1f0-4f09-84ab-014dfbea0427" />
<img width="430" alt="image" src="https://github.com/user-attachments/assets/adb9f0b6-4cfe-4f51-a0a8-4a15102e3271" />

Ignoring the anchoring issues which I have opened PR to rmc-scrybbling to fix, I think the ballpoint pen is a bit too thick, the highlighter too faded and slightly too think, the calligraphy pen (the "hello" text) too thick, and the paintbrush (the red and light blue strokes on the second page) too big.

With the PR, the above issues are fixed, the pages look like:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/27886178-1fe5-4ad0-b4d6-1b2f91a768fe" />
<img width="430" alt="image" src="https://github.com/user-attachments/assets/d9c03105-8aef-4e5c-8f81-dae9c3b29d18" />

The ballpoint thickness is a subtle change. Here's a comparison of original remarks (left), my PR (middle), and the official app (right)
<img width="500" alt="image" src="https://github.com/user-attachments/assets/744c7532-8e73-47e4-979f-727d1aa74f4a" />

I've taken these screenshot with changes from all PRs I've recently opened taken, so the only change this specific PR adds is the tweaks mentioned, not the anchoring fixes / template support.